### PR TITLE
Target new cdk toolkit stack

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,6 @@ npx cdk \
   --verbose \
   --execute true \
   --force \
-  --toolkit-stack-name "cdk-toolkit-master-${ACCOUNT_ID}" \
+  --toolkit-stack-name "cdk-toolkit-master" \
   --app "ts-node ./src/index.ts" \
   deploy


### PR DESCRIPTION
We've updated the `cdk-toolkit` stack so we now want to target it. This should probably be pulled back to an organisational configuration layer but small steps...