### PR TITLE
Fix Previous Module Build Error

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Attempting to fix the error:

```
/home/runner/work/iam-entities/iam-entities/src/index.ts:1
import { App } from '@aws-cdk/core';
^^^^^^
```

`SyntaxError: Cannot use import statement outside a module`